### PR TITLE
Update isThingNameTopicMatch()

### DIFF
--- a/test/cbmc/run_proofs.sh
+++ b/test/cbmc/run_proofs.sh
@@ -13,9 +13,9 @@ coreJSONSourceDir="coreJSON/source"
 exec cbmc proofs.c "$JobsSourceDir/jobs.c"  stubs/strnlen.c \
      stubs/JSON_Validate.c stubs/JSON_SearchT.c \
      -I $JobsSourceDir/include -I $coreJSONSourceDir/include -I include  \
-     --unwindset strnAppend.0:15 --unwindset strnEq.0:26 \
+     --unwindset strnAppend.0:20 --unwindset strnEq.0:26 \
      --unwindset matchIdApi.0:84 --unwindset isValidID.0:65 \
-     --unwindset strlen.0:36 \
+     --unwindset strlen.0:46 \
      --bounds-check --pointer-check --memory-cleanup-check --div-by-zero-check \
      --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check \
      --conversion-check --undefined-shift-check --enum-range-check \


### PR DESCRIPTION
Update isThingNameTopicMatch() to use writePreamble() and strnAppend() instead of memcpy and snprintf().